### PR TITLE
Allow setting the python path as an env var

### DIFF
--- a/managepy.js
+++ b/managepy.js
@@ -9,6 +9,7 @@ module.exports = function managePy(djangopath, params = [], options = {}) {
   );
 
   const pythonPathCandidates = [
+    process.env.DJANGO_PYTHON_PATH,
     'bin/python',
     '.tox/py36/bin/python',
   ];


### PR DESCRIPTION
The python path on the CI has changed, and we can't maintain a list with all paths.