### PR TITLE
Prevent naming conflict for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,13 @@ The headless mode runs the tests in the background. This is best for running the
 ```bash
 vue-cli-service test:django:e2e:headless --djangopath=/path/to/django/root
 ```
+
+### Environment variables
+
+Following (optional) environment variables can be made use of:
+
+- **```DJANGO_E2E_DATABASE_NAME```**: The name of the database used by django. Defaults to ```E2E_TESTING_34000```
+- **```DJANGO_PYTHON_PATH```**: The path to the python binary used by django. Defaults to ```'bin/python', '.tox/py36/bin/python', 'python'```
+- **```PORT1```**: The port used by django. Defaults to ```34000```
+- **```PORT2```**: The port used by vue. Defaults to ```35000```
+- **```PORT3```**: The port used by cypress. Defaults to ```36000```

--- a/settings.js
+++ b/settings.js
@@ -14,7 +14,7 @@ module.exports = (async () => {
   const FRONTEND_PORT = process.env.PORT2 || FRONTEND_PORT_DEFAULT;
   const CYPRESS_PORT = process.env.PORT3 || CYPRESS_PORT_DEFAULT;
 
-  const DJANGO_DATABASE_NAME = process.env.DJANGO_DATABASE_NAME || `E2E_TESTING_${BACKEND_PORT}`;
+  const DJANGO_DATABASE_NAME = process.env.DJANGO_E2E_DATABASE_NAME || `E2E_TESTING_${BACKEND_PORT}`;
 
   return {
     BACKEND_PORT,


### PR DESCRIPTION
The previous name clashed with the default used by RIS. 🙈 
Also, some documentation