### PR TITLE
Extend configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The plugin requires the cypress binary. https://www.npmjs.com/package/cypress
 
 ### manage.py
 
-The plugin is able to interact with the django server and database. Therefore it is imporant to provide the djangopath when executing the tests. The djangopath should be the root directory of your project. The plugin assumes to have a `manage.py` to interact with the django server.
+The plugin is able to interact with the django server and database. Therefore it is important to provide the djangopath when executing the tests. The djangopath should be the root directory of your project. The plugin assumes to have a `manage.py` to interact with the django server.
 
 ### database scripts
 
@@ -47,8 +47,18 @@ vue-cli-service test:django:e2e --djangopath=/path/to/django/root
 The headless mode runs the tests in the background. This is best for running the tests in a pipeline on an integration server.
 
 ```bash
-vue-cli-service test:django:e2e:headless --djangopath=/path/to/django/root
+vue-cli-service test:django:e2e --djangopath=/path/to/django/root --headless
 ```
+
+### Using a `.env` file
+
+You may specify a mode, which loads a corresponding `.env.[mode]` file that allows you to specify environment variables.
+
+```bash
+vue-cli-service test:django:e2e --djangopath=/path/to/django/root --mode testing_e2e
+```
+
+Above example will look for a file called `.env.testing_e2e` and pick up the environment variables specified in this file.
 
 ### Environment variables
 
@@ -56,6 +66,9 @@ Following (optional) environment variables can be made use of:
 
 - **```DJANGO_E2E_DATABASE_NAME```**: The name of the database used by django. Defaults to ```E2E_TESTING_34000```
 - **```DJANGO_PYTHON_PATH```**: The path to the python binary used by django. Defaults to ```'bin/python', '.tox/py36/bin/python', 'python'```
+- **```DJANGO_CONFIGURATION```**: The name of the django settings class. Defaults to ```'TestingE2E'```
 - **```PORT1```**: The port used by django. Defaults to ```34000```
 - **```PORT2```**: The port used by vue. Defaults to ```35000```
 - **```PORT3```**: The port used by cypress. Defaults to ```36000```
+- **```HEARTBEAT_PATH```**: The frontend server will only start once the backend server is ready. A relative URL is requested repeatedly to check if the backend server is ready yet, using a HTTP HEAD method and waiting for a 200 or 302 status code. Defaults to ```/```
+- **```CYPRESS_CONFIG```**: Override Cypress options, passed as a string as `--config` when running Cypress (https://docs.cypress.io/guides/references/configuration.html#Overriding-Options). Defaults to ```''``` (```baseUrl=http://localhost:[PORT2]``` is always passed)

--- a/database.js
+++ b/database.js
@@ -8,19 +8,21 @@ const managePy = require('./managepy');
 let instance = null;
 
 class Database {
-  constructor(djangopath, databasename) {
+  constructor({ djangopath, DJANGO_DATABASE_NAME }) {
     if(!instance){
       instance = this;
     }
 
     this.djangopath = djangopath;
-    this.databasename = databasename;
+    this.databasename = DJANGO_DATABASE_NAME;
+
+    process.env.DJANGO_DATABASE_NAME = this.databasename;
+    process.env.djangopath = this.djangopath;
 
     return instance;
   }
 
   async create() {
-    process.env.DJANGO_DATABASE_NAME = this.databasename;
     try {
       info(`Creating database: '${this.databasename}'...`);
       await execa('./bin/e2e_setup_db', [this.databasename], { cwd: this.djangopath });

--- a/index.js
+++ b/index.js
@@ -3,28 +3,19 @@ const start = require('./start');
 module.exports = (api, options) => {
   api.registerCommand('test:django:e2e',
     {
-      description: 'Execute e2e tests in interactive mode',
-      usage: 'vue-cli-servce test:django:e2e --djangopath=/path/of/django/project',
+      description: 'Execute e2e tests',
+      usage: 'vue-cli-service test:django:e2e --djangopath=/path/of/django/project',
       options: {
-        '--djangopath': 'Specifiy root path to django project',
+        '--djangopath': 'Specify root path to django project',
+        '--headless': 'Run in headless mode',
+        '--mode': 'Loads a corresponding .env.[mode] file',
+        '--gever': 'Use a real GEVER backend',
       },
     },
     async (args) => { await start(api, Object.assign(options, args)); }
   );
-
-  api.registerCommand('test:django:e2e:headless',
-    {
-      description: 'Execute e2e tests in headless mode',
-      usage: 'vue-cli-servce test:django:e2e:headless --djangopath=/path/of/django/project',
-      options: {
-        '--djangopath': 'Specifiy root path to django project',
-      },
-    },
-    async (args) => { await start(api, Object.assign(options, { headless: true }, args)); }
-  );
-}
+};
 
 module.exports.defaultModes = {
-  'test:django:e2e': 'test',
-  'test:django:e2e:headless': 'test',
-}
+  'test:django:e2e': 'production',
+};

--- a/managepy.js
+++ b/managepy.js
@@ -3,10 +3,7 @@ const path = require('path');
 const fs = require('fs');
 
 module.exports = function managePy(djangopath, params = [], options = {}) {
-  const env = Object.assign(
-    options.env || {},
-    { DJANGO_CONFIGURATION: 'TestingE2E' },
-  );
+  const env = options.env || {};
 
   const pythonPathCandidates = [
     process.env.DJANGO_PYTHON_PATH,

--- a/processes/Process.js
+++ b/processes/Process.js
@@ -1,7 +1,6 @@
 class Process {
-  constructor(settings, options) {
-    this.settings = settings;
-    this.options = options;
+  constructor(config = {}) {
+    this.config = config;
   }
 
   async start() {

--- a/processes/backend.js
+++ b/processes/backend.js
@@ -7,19 +7,19 @@ const http = require('http');
 /**
  * Represents the python backend.
  * @constructor
- * @param {object} settings - Settings must contain the django database name and the backend port.
+ * @param {object} config - Config must contain the django database name and the backend port.
  */
 class Backend extends Process {
   /**
    * Starts a django backend server using `manage.py` on the preconfigured port
    */
   start() {
-    const { BACKEND_PORT } = this.settings;
+    const { BACKEND_PORT, djangopath } = this.config;
     info(`Starting backend server on http://localhost:${BACKEND_PORT}...`);
     this.process = managePy(
-      this.options.djangopath,
+      djangopath,
       ['runserver', BACKEND_PORT],
-      { env: this.settings, stdout: 'inherit' },
+      { env: this.config, stdout: 'inherit' },
     );
     return this.heartbeat();
   }
@@ -28,12 +28,12 @@ class Backend extends Process {
    * Checks if the backend server is ready to handle requests
    */
   heartbeat() {
-    const { BACKEND_PORT } = this.settings;
+    const { BACKEND_PORT, HEARTBEAT_PATH } = this.config;
     const options = {
       method: 'HEAD',
       host: 'localhost',
       port: BACKEND_PORT,
-      path: '/',
+      path: HEARTBEAT_PATH,
       timeout: 2 * 60 * 1000,
     };
 
@@ -52,7 +52,7 @@ class Backend extends Process {
           rej();
         });
         req.on('response', ({ statusCode }) => {
-          if (statusCode === 302) {
+          if (statusCode === 200 || statusCode === 302) {
             res();
           } else {
             rej();

--- a/processes/cypress.js
+++ b/processes/cypress.js
@@ -4,24 +4,37 @@ const Process = require('./Process');
 /**
  * Represents the cypress test runner.
  * @constructor
- * @param {object} settings - Settings must contain the cypress port.
+ * @param {object} config - Config must contain the cypress port.
  */
 class Cypress extends Process {
   /**
    *
-   * @param {object} frontend - The frontend is needed to determine the url
    */
-  start({ headless, djangopath, gever }) {
-    // Actaul cypress binary from node modules
+  start() {
+    // Actual cypress binary from node modules
     const cypressBin = require.resolve('cypress/bin/cypress');
-    const { CYPRESS_PORT, FRONTEND_PORT, DJANGO_DATABASE_NAME } = this.settings;
+    const {
+      CYPRESS_PORT,
+      FRONTEND_PORT,
+      DJANGO_DATABASE_NAME,
+      CYPRESS_CONFIG,
+      headless,
+      djangopath,
+      gever,
+    } = this.config;
     info(`Running E2E tests on http://localhost:${CYPRESS_PORT} ...`);
+
+    const cypressConfig = [
+      `baseUrl=http://localhost:${FRONTEND_PORT}`,
+      CYPRESS_CONFIG,
+    ].filter(Boolean).join(',');
+
     this.process = execa(
       cypressBin,
       [
         headless ? 'run' : 'open',
         '--config',
-        `baseUrl=http://localhost:${FRONTEND_PORT}`,
+        cypressConfig,
         `--port=${CYPRESS_PORT}`,
         '--env',
         `GEVER=${gever}`,

--- a/processes/frontend.js
+++ b/processes/frontend.js
@@ -5,17 +5,16 @@ const Process = require('./Process');
 /**
  * Represents the frontend server
  * @constructor
- * @param {object} settings - settings must contain the backend and frontend port
+ * @param {object} config - Config must contain the frontend port.
  */
 class Frontend extends Process {
   /**
    * Start the frontend server using the vue-cli-service
    */
   async start(api) {
-    const { FRONTEND_PORT } = this.settings;
+    const { FRONTEND_PORT } = this.config;
 
     info(`Starting frontend server on http://localhost:${FRONTEND_PORT}...`);
-    process.env.NODE_ENV = 'production';
     this.process = await api.service.run('serve', {
       port: FRONTEND_PORT,
     });

--- a/settings.js
+++ b/settings.js
@@ -15,11 +15,13 @@ module.exports = (async () => {
   const CYPRESS_PORT = process.env.PORT3 || CYPRESS_PORT_DEFAULT;
 
   const DJANGO_DATABASE_NAME = process.env.DJANGO_E2E_DATABASE_NAME || `E2E_TESTING_${BACKEND_PORT}`;
+  const DJANGO_CONFIGURATION = process.env.DJANGO_CONFIGURATION || 'TestingE2E';
 
   return {
     BACKEND_PORT,
     FRONTEND_PORT,
     CYPRESS_PORT,
     DJANGO_DATABASE_NAME,
+    DJANGO_CONFIGURATION,
   };
 })();


### PR DESCRIPTION
- `--headless` can be passed to avoid `:headless` and duplication of commands.
- `--mode` can be passed to read environment variables from a file.
- `DJANGO_CONFIGURATION` allows to specify a settings class for Django.
- `CYPRESS_CONFIG` allows to override Cypress options.
- `HEARTBEAT_PATH` allows to specify the path requested by the backend heartbeat before starting the frontend.
- Heartbeat also listens to status code 200.