### PR TITLE
Run Django server in singlethreaded mode.

### DIFF
--- a/processes/backend.js
+++ b/processes/backend.js
@@ -18,7 +18,7 @@ class Backend extends Process {
     info(`Starting backend server on http://localhost:${BACKEND_PORT}...`);
     this.process = managePy(
       djangopath,
-      ['runserver', BACKEND_PORT],
+      ['runserver', '--nothreading', BACKEND_PORT],
       { env: this.config, stdout: 'inherit' },
     );
     return this.heartbeat();


### PR DESCRIPTION
When running the Django server in multithreaded mode and against the tapes, recorded requests are sometimes not found. Running the tests on a singlethreaded Django server should prevent this.