### PR TITLE
Run selected tests headless and accessible backend port in loaddata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ The headless mode runs the tests in the background. This is best for running the
 vue-cli-service test:django:e2e --djangopath=/path/to/django/root --headless
 ```
 
+### Specifying test files to run
+
+If you want to run only selected test file(s) in headless mode instead of running all tests, specify the path of the file using `--spec`. This is then passed to Cypress (see https://docs.cypress.io/guides/guides/command-line.html#cypress-run-spec-lt-spec-gt).   
+
+```bash
+vue-cli-service test:django:e2e --headless --spec=tests/e2e/specs/some.spec.js
+```
+
 ### Using a `.env` file
 
 You may specify a mode, which loads a corresponding `.env.[mode]` file that allows you to specify environment variables.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ module.exports = (on, config) => {
 
 The management command `load_e2e_data` is required if specific data should be loaded on a 'per test' basis. The command should accept an optional parameter: `--datasets`.
 
+The command has access to the `BACKEND_PORT` (the port on which the server is currently running). Example: `os.environ.get("BACKEND_PORT", 8000)`.
+
 ### Interactive mode
 
 The interactive mode enables you to run the e2e tests in the cypress electron app. This is best for development because you have hot reload when the production or test code is updated. You are also able to interact with the application after the tests are done.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ so they can be called in setup and teardown hooks:
 module.exports = (on, config) => {
   on('task', {
     djangoTestSetup({ test, gever }) {
-      database.reset(),
+      database.reset();
     },
     loadData(dataSet) {
       return database.load(dataSet);

--- a/database.js
+++ b/database.js
@@ -8,16 +8,18 @@ const managePy = require('./managepy');
 let instance = null;
 
 class Database {
-  constructor({ djangopath, DJANGO_DATABASE_NAME }) {
+  constructor({ djangopath, DJANGO_DATABASE_NAME, BACKEND_PORT }) {
     if(!instance){
       instance = this;
     }
 
     this.djangopath = djangopath;
     this.databasename = DJANGO_DATABASE_NAME;
+    this.backend_port = BACKEND_PORT;
 
     process.env.DJANGO_DATABASE_NAME = this.databasename;
     process.env.djangopath = this.djangopath;
+    process.env.BACKEND_PORT = this.backend_port;
 
     return instance;
   }
@@ -48,7 +50,7 @@ class Database {
     return managePy(
       this.djangopath,
       ['load_e2e_data', '--datasets', dataset],
-      { stdout: 'inherit' },
+      { stdout: 'inherit', env: { BACKEND_PORT: this.backend_port } },
     );
   }
 }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = (api, options) => {
         '--headless': 'Run in headless mode',
         '--mode': 'Loads a corresponding .env.[mode] file',
         '--gever': 'Use a real GEVER backend',
+        '--spec': 'Specify which test file(s) to run instead of running all tests'
       },
     },
     async (args) => { await start(api, Object.assign(options, args)); }

--- a/processes/cypress.js
+++ b/processes/cypress.js
@@ -18,6 +18,7 @@ class Cypress extends Process {
       FRONTEND_PORT,
       DJANGO_DATABASE_NAME,
       CYPRESS_CONFIG,
+      spec,
       headless,
       djangopath,
       gever,
@@ -38,6 +39,7 @@ class Cypress extends Process {
         `--port=${CYPRESS_PORT}`,
         '--env',
         `GEVER=${gever}`,
+        ...(spec ? ['--spec', spec] : [])
       ],
       { stdio: 'inherit', env: { DJANGO_DATABASE_NAME, DJANGO_PATH: djangopath } },
     );


### PR DESCRIPTION
- Make backend port accessible in loaddata command.
- Allow specification of single test file(s) to run in headless mode.