### PR TITLE
New option to disable starting the backend server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ vue-cli-service test:django:e2e --djangopath=/path/to/django/root --mode testing
 
 Above example will look for a file called `.env.testing_e2e` and pick up the environment variables specified in this file.
 
+### Without runserver
+
+By default, the backend server is started using Django's ``python manage.py runserver`` command.
+
+If you want to prevent this and run the tests against a backend which is already running (e.g. started using uwsgi), you can set ``--runserver=false``. In this case you need to explicitly pass the port of the backend server using the environment variable ``BACKEND_PORT``.
+
+```bash
+vue-cli-service test:django:e2e --djangopath=/path/to/django/root --runserver=false
+```
+
 ### Environment variables
 
 Following (optional) environment variables can be made use of:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 const start = require('./start');
 
+const defaults = {
+  'runserver': true,
+}
+
 module.exports = (api, options) => {
   api.registerCommand('test:django:e2e',
     {
@@ -10,10 +14,14 @@ module.exports = (api, options) => {
         '--headless': 'Run in headless mode',
         '--mode': 'Loads a corresponding .env.[mode] file',
         '--gever': 'Use a real GEVER backend',
-        '--spec': 'Specify which test file(s) to run instead of running all tests'
+        '--spec': 'Specify which test file(s) to run instead of running all tests',
+        '--runserver': `Also start the backend (with Django's runserver) (default: ${defaults["runserver"]})`
       },
     },
-    async (args) => { await start(api, Object.assign(options, args)); }
+    async (args) => {
+      args = Object.assign(defaults, args)
+      await start(api, Object.assign(options, args));
+    }
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "tree-kill": "^1.2.1"
   },
   "peerDependencies": {
-    "cypress": "^3.8.1"
+    "cypress": "*"
   }
 }


### PR DESCRIPTION
In some cases, it might be useful to run the tests against a backend which is already started (e.g. using uwsgi). In this case, the command to start Django's runserver should not be executed.

A new option `--runserver` allows to do this. It defaults to `true`, meaning that the backend server is started. If passed as `--runserver=false`, this behaviour is disabled.