### PR TITLE
Pass `record` flag to Cypress

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ module.exports = (api, options) => {
         '--gever': 'Use a real GEVER backend',
         '--spec': 'Specify which test file(s) to run instead of running all tests',
         '--runserver': `Also start the backend (with Django's runserver) (default: ${defaults.runserver})`,
-        '--quiet': `Do not output summary of tests (default: ${defaults.quiet})`
+        '--quiet': `Do not output summary of tests (default: ${defaults.quiet})`,
+        '--record': `Pass test results to Cypress dashboard (use env variables CYPRESS_RECORD_KEY and CYPRESS_PROJECT_ID)`
       },
     },
     async (args) => {

--- a/processes/cypress.js
+++ b/processes/cypress.js
@@ -23,6 +23,7 @@ class Cypress extends Process {
       headless,
       djangopath,
       quiet,
+      record,
     } = this.config;
     info(`Running E2E tests on http://localhost:${CYPRESS_PORT} ...`);
 
@@ -42,6 +43,7 @@ class Cypress extends Process {
         `GEVER_PORT=${GEVER_PORT}`,
         ...(spec ? ['--spec', spec] : []),
         ...(headless && quiet ? ['--quiet', quiet] : []),
+        ...(record ? ['--record', record] : []),
       ],
       { stdio: 'inherit', env: { DJANGO_DATABASE_NAME, DJANGO_PATH: djangopath } },
     );


### PR DESCRIPTION
This allows test results to be written to Cypress dashboard.