### PR TITLE
Pass `browser` flag to Cypress

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = (api, options) => {
         '--spec': 'Specify which test file(s) to run instead of running all tests',
         '--runserver': `Also start the backend (with Django's runserver) (default: ${defaults.runserver})`,
         '--quiet': `Do not output summary of tests (default: ${defaults.quiet})`,
-        '--record': `Pass test results to Cypress dashboard (use env variables CYPRESS_RECORD_KEY and CYPRESS_PROJECT_ID)`
+        '--record': `Pass test results to Cypress dashboard (use env variables CYPRESS_RECORD_KEY and CYPRESS_PROJECT_ID)`,
+        '--browser': `Indicate on which browser tests should be run`
       },
     },
     async (args) => {

--- a/processes/cypress.js
+++ b/processes/cypress.js
@@ -24,6 +24,7 @@ class Cypress extends Process {
       djangopath,
       quiet,
       record,
+      browser,
     } = this.config;
     info(`Running E2E tests on http://localhost:${CYPRESS_PORT} ...`);
 
@@ -44,6 +45,7 @@ class Cypress extends Process {
         ...(spec ? ['--spec', spec] : []),
         ...(headless && quiet ? ['--quiet', quiet] : []),
         ...(record ? ['--record', record] : []),
+        ...(browser ? ['--browser', browser] : []),
       ],
       { stdio: 'inherit', env: { DJANGO_DATABASE_NAME, DJANGO_PATH: djangopath } },
     );


### PR DESCRIPTION
Allow to select on which browser tests should be run.